### PR TITLE
Update class-post-content-clean.php

### DIFF
--- a/kapow-core/php/content/class-post-content-clean.php
+++ b/kapow-core/php/content/class-post-content-clean.php
@@ -231,6 +231,10 @@ class Post_Content_Clean {
 				'id'    => array(),
 				'class' => array(),
 			),
+			'figure'     => array(
+				'id'    => array(),
+				'class' => array(),
+			),
 		);
 
 		// Filter the content tags, so we can add additional.


### PR DESCRIPTION
Update class-post-content-clean.php to include `figure` into the allowed list of tags for the_content()

## Description

Update class-post-content-clean.php to include `figure` into the allowed list of tags for the_content(). This will assist with Gutenberg and allowing `alignwide` & `alignfull`

*For review by @davetgreen @mwtsn*
